### PR TITLE
feature flag on a previous PR optimization

### DIFF
--- a/src/main/java/com/wecca/canoeanalysis/components/graphics/CurvedGraphic.java
+++ b/src/main/java/com/wecca/canoeanalysis/components/graphics/CurvedGraphic.java
@@ -38,20 +38,24 @@ public class CurvedGraphic extends Group implements FunctionGraphic {
      * Deals with mapping between function space and graphic space
      * @param function the function definition in function space
      * @param section the interval of the function in function space
-     * @param encasingRectangle the smallest region in function space that encloses all points in the function
-     *                          is mapped to this rectangle in graphics space
+     * @param encasingRectangle the smallest region in function space that encloses all points in the function is mapped to this rectangle in graphics space
      */
     public CurvedGraphic(BoundedUnivariateFunction function, Section section, Rectangle encasingRectangle, boolean fillCurve) {
+        this(function, section, encasingRectangle, fillCurve, false);
+    }
+
+    /**
+     * @param useUnimodalOptimization, an extra flag to optimize the function faster for quick renders which only works for unimodal functions
+     *                                 it is up to the implementer to understand if the function is unimodal as the cost to validate for this makes the optimization it provides redundant!
+     */
+    public CurvedGraphic(BoundedUnivariateFunction function, Section section, Rectangle encasingRectangle, boolean fillCurve, boolean useUnimodalOptimization) {
         super();
         this.function = function;
         this.section = section;
         this.encasingRectangle = encasingRectangle;
-        this.maxSignedValue = function.getMaxSignedValue(section); // precalculated to save time fetching
         this.isColored = false;
         this.isFilled = fillCurve;
-
-        // Commented out to improve rendering speed, but should be enforced... be careful lol
-        // CalculusUtils.validatePiecewiseAsUpOrDown(List.of(function), List.of(section));
+        this.maxSignedValue = useUnimodalOptimization ? function.getMaxSignedValueUnimodal(section) : function.getMaxSignedValue(section);
 
         draw();
         JFXDepthManager.setDepth(this, 4);

--- a/src/main/java/com/wecca/canoeanalysis/components/graphics/hull/CubicBezierSplineHullGraphic.java
+++ b/src/main/java/com/wecca/canoeanalysis/components/graphics/hull/CubicBezierSplineHullGraphic.java
@@ -29,7 +29,16 @@ public class CubicBezierSplineHullGraphic extends HullGraphic {
      *                          which is mapped to this rectangle in graphics space.
      */
     public CubicBezierSplineHullGraphic(List<CubicBezierFunction> beziers, Rectangle encasingRectangle) {
-        super(CalculusUtils.createBezierSplineFunctionShiftedPositive(beziers), new Section(beziers.getFirst().getX(), beziers.getLast().getRx()), encasingRectangle);
+        this(beziers, encasingRectangle, false);
+    }
+
+    /**
+     * @param useUnimodalOptimization, an extra flag to optimize the function faster for quick renders which only works for unimodal functions
+     *                                 it is up to the implementer to understand if the function is unimodal as the cost to validate for this makes the optimization it provides redundant!
+     *                                 logically, a hull shape should probably almost always meet these criteria anyway!
+     */
+    public CubicBezierSplineHullGraphic(List<CubicBezierFunction> beziers, Rectangle encasingRectangle, boolean useUnimodalOptimization) {
+        super(CalculusUtils.createBezierSplineFunctionShiftedPositive(beziers, useUnimodalOptimization), new Section(beziers.getFirst().getX(), beziers.getLast().getRx()), encasingRectangle, useUnimodalOptimization);
         this.beziers = beziers;
         this.slopeGraphics = new ArrayList<>();
         this.getCurvedGraphic().setEncasingRectangle(encasingRectangle);

--- a/src/main/java/com/wecca/canoeanalysis/components/graphics/hull/HullGraphic.java
+++ b/src/main/java/com/wecca/canoeanalysis/components/graphics/hull/HullGraphic.java
@@ -31,8 +31,17 @@ public class HullGraphic extends Group implements FunctionGraphic {
      *                          is mapped to this rectangle in graphics space
      */
     public HullGraphic(BoundedUnivariateFunction function, Section section, Rectangle encasingRectangle) {
+        this(function, section, encasingRectangle, false);
+    }
+
+    /**
+     * @param useUnimodalOptimization, an extra flag to optimize the function faster for quick renders which only works for unimodal functions
+     *                                 it is up to the implementer to understand if the function is unimodal as the cost to validate for this makes the optimization it provides redundant!
+     *                                 logically, a hull shape should probably almost always meet these criteria anyway!
+     */
+    public HullGraphic(BoundedUnivariateFunction function, Section section, Rectangle encasingRectangle, boolean useUnimodalOptimization) {
         this.closingTopLine = new Line(encasingRectangle.getX(), encasingRectangle.getY(), encasingRectangle.getX() + encasingRectangle.getWidth(), encasingRectangle.getY());
-        this.curvedGraphic = new CurvedGraphic(function, section, encasingRectangle, true);
+        this.curvedGraphic = new CurvedGraphic(function, section, encasingRectangle, true, useUnimodalOptimization);
         draw();
     }
 

--- a/src/main/java/com/wecca/canoeanalysis/controllers/modules/HullBuilderController.java
+++ b/src/main/java/com/wecca/canoeanalysis/controllers/modules/HullBuilderController.java
@@ -336,7 +336,7 @@ public class HullBuilderController implements Initializable {
             else
                 throw new RuntimeException("Not a bezier hull");
         }).toList();
-        hullGraphic = new CubicBezierSplineHullGraphic(beziers, rect);
+        hullGraphic = new CubicBezierSplineHullGraphic(beziers, rect, true);
 
         // Add graphic to pane
         hullGraphicPane.getChildren().clear();

--- a/src/main/java/com/wecca/canoeanalysis/models/canoe/Hull.java
+++ b/src/main/java/com/wecca/canoeanalysis/models/canoe/Hull.java
@@ -217,7 +217,7 @@ public class Hull {
     public BoundedUnivariateFunction getPiecedSideProfileCurveShiftedAboveYAxis() {
         List<BoundedUnivariateFunction> functions = hullSections.stream().map(HullSection::getSideProfileCurve).toList();
         List<Section> sections = hullSections.stream().map(sec -> (Section) sec).toList();
-        return CalculusUtils.createCompositeFunctionShiftedPositive(functions, sections);
+        return CalculusUtils.createCompositeFunctionShiftedPositive(functions, sections, false);
     }
 
     /**

--- a/src/main/java/com/wecca/canoeanalysis/models/function/BoundedUnivariateFunction.java
+++ b/src/main/java/com/wecca/canoeanalysis/models/function/BoundedUnivariateFunction.java
@@ -1,6 +1,5 @@
 package com.wecca.canoeanalysis.models.function;
 
-import com.wecca.canoeanalysis.aop.Traceable;
 import javafx.geometry.Point2D;
 import org.apache.commons.math3.analysis.UnivariateFunction;
 import org.apache.commons.math3.optim.MaxEval;
@@ -12,34 +11,103 @@ import org.apache.commons.math3.optim.univariate.UnivariatePointValuePair;
 
 /**
  * A function which has bounded y-values on its domain, some subset of R^+
+ *
+ * The implementer can either use methods from the original API, or the newer unimodal API
+ * BeamController was originally implemented with the old API, and the new API was designed for HullBuilderController
+ * The new API using Brent's method requires the function to be unimodal (one maximum in the section)
+ * Constant value uniformly distributed loads break this because each point is equal and there are infinite maximums then
+ * Thus to avoid changing old BeamController code which may break it, the API has been expanded
+ * The option to use the new version of the API is left up to the implementer, they must manually switch over the optimized API
  */
 public interface BoundedUnivariateFunction extends UnivariateFunction {
 
+    // ===== Original API: Manual Optimization (100 steps) =====
+
     /**
-     * @param section the section within which to find the minimum
-     * @return the minimum point (x, y) of the function within the specified section.
+     * Gets the minimum point of the function within a specific section.
+     * @param section the section within which to find the minimum point
+     * @return the point (x, y) where the function has its minimum value within the specified section
      */
     default Point2D getMinPoint(Section section) {
-        return optimize(section, GoalType.MINIMIZE);
+        double step = (section.getRx() - section.getX()) / 100;
+        double xMin = section.getX();
+        double yMin = value(xMin);
+        for (double x = section.getX(); x <= section.getRx(); x += step) {
+            double y = value(x);
+            if (y < yMin) {
+                yMin = y;
+                xMin = x;
+            }
+        }
+        return new Point2D(xMin, yMin);
     }
 
     /**
-     * @param section the section within which to find the maximum
-     * @return the maximum point (x, y) of the function within the specified section.
+     * Gets the maximum point of the function within a specific section.
+     * @param section the section within which to find the maximum point
+     * @return the point (x, y) where the function has its maximum value within the specified section
      */
     default Point2D getMaxPoint(Section section) {
-        return optimize(section, GoalType.MAXIMIZE);
+        double step = (section.getRx() - section.getX()) / 100;
+        double xMax = section.getX();
+        double yMax = value(xMax);
+        for (double x = section.getX(); x <= section.getRx(); x += step) {
+            double y = value(x);
+            if (y > yMax) {
+                yMax = y;
+                xMax = x;
+            }
+        }
+        return new Point2D(xMax, yMax);
     }
 
     /**
-     * Optimizes the function to find the minimum or maximum point within a section.
-     * Uses a hybrid Manual search + Brent's method strategy to balance drawbacks of each
+     * Returns the point of either the minimum or maximum (whichever has the higher absolute y-value)
+     * @param section the section within which to find the optimum
+     * @return the optimum point (x, y) on the interval [x, rx]
+     */
+    default Point2D getMaxSignedValuePoint(Section section) {
+        Point2D minPoint = getMinPoint(section);
+        Point2D maxPoint = getMaxPoint(section);
+        return Math.abs(minPoint.getY()) > Math.abs(maxPoint.getY()) ? minPoint : maxPoint;
+    }
+
+    /**
+     * Gets the minimum value of the function within a specific section.
+     * @param section the section within which to find the minimum value
+     * @return the minimum value within the specified section
+     */
+    default double getMinValue(Section section) {
+        return getMinPoint(section).getY();
+    }
+
+    /**
+     * Gets the maximum value of the function within a specific section.
+     * @param section the section within which to find the maximum value
+     * @return the maximum value within the specified section
+     */
+    default double getMaxValue(Section section) {
+        return getMaxPoint(section).getY();
+    }
+
+    /**
+     * Gets the optimum (max signed value) of the function within a specific section.
+     * @param section the section within which to find the optimum
+     * @return the y value of the function's optimum within the specified section
+     */
+    default double getMaxSignedValue(Section section) {
+        return getMaxSignedValuePoint(section).getY();
+    }
+
+    // ===== New API: Unimodal Optimization Using Brent's Method =====
+
+    /**
+     * Optimizes the function using a hybrid manual search (10 steps) plus Brent's method.
      * @param section  the section within which to perform the optimization
      * @param goalType the optimization goal (minimize or maximize)
-     * @return the optimal point (x, y)
+     * @return the optimum point (x, y)
      */
-    private Point2D optimize(Section section, GoalType goalType) {
-        // Manual search to narrow the range, very coarse to negate performance concerns
+    private Point2D optimizeUnimodal(Section section, GoalType goalType) {
         double xStart = section.getX();
         double xEnd = section.getRx();
         double step = (xEnd - xStart) / 10.0;
@@ -53,11 +121,8 @@ public interface BoundedUnivariateFunction extends UnivariateFunction {
                 bestY = y;
             }
         }
-        // Define a narrow range to do a more precise search
         double lower = Math.max(xStart, bestX - step);
         double upper = Math.min(xEnd, bestX + step);
-
-        // Refine the result using Brent's method
         BrentOptimizer optimizer = new BrentOptimizer(1e-10, 1e-8);
         UnivariatePointValuePair result = optimizer.optimize(
                 new MaxEval(1000),
@@ -69,39 +134,58 @@ public interface BoundedUnivariateFunction extends UnivariateFunction {
     }
 
     /**
-     * Returns the point of either the minimum or maximum, whichever y-value at the optimum has the higher absolute value
-     * @param section the section within which to find the maximum point
-     * @return the point (x, y), the function's optimum on the interval [x, rx]
+     * Gets the minimum point of the function within a specific section using unimodal optimization.
+     * @param section the section within which to find the minimum point
+     * @return the point (x, y) where the function has its minimum value within the specified section
      */
-    default Point2D getMaxSignedValuePoint(Section section) {
-        Point2D minPoint = getMinPoint(section);
-        Point2D maxPoint = getMaxPoint(section);
+    default Point2D getMinPointUnimodal(Section section) {
+        return optimizeUnimodal(section, GoalType.MINIMIZE);
+    }
+
+    /**
+     * Gets the maximum point of the function within a specific section using unimodal optimization.
+     * @param section the section within which to find the maximum point
+     * @return the point (x, y) where the function has its maximum value within the specified section
+     */
+    default Point2D getMaxPointUnimodal(Section section) {
+        return optimizeUnimodal(section, GoalType.MAXIMIZE);
+    }
+
+    /**
+     * Returns the optimum point (with the higher absolute y-value) using unimodal optimization.
+     * @param section the section within which to find the optimum
+     * @return the optimum point (x, y) on the interval [x, rx]
+     */
+    default Point2D getMaxSignedValuePointUnimodal(Section section) {
+        Point2D minPoint = getMinPointUnimodal(section);
+        Point2D maxPoint = getMaxPointUnimodal(section);
         return Math.abs(minPoint.getY()) > Math.abs(maxPoint.getY()) ? minPoint : maxPoint;
     }
 
     /**
-     * Gets the minimum value of the function within a specific section.
+     * Gets the minimum value of the function within a specific section using unimodal optimization.
      * @param section the section within which to find the minimum value
-     * @return the minimum value of the function within the specified section
+     * @return the minimum value within the specified section
      */
-    default double getMinValue(Section section) {
-        return getMinPoint(section).getY();
+    default double getMinValueUnimodal(Section section) {
+        return getMinPointUnimodal(section).getY();
     }
 
     /**
-     * Gets the maximum value of the function within a specific section.
+     * Gets the maximum value of the function within a specific section using unimodal optimization.
      * @param section the section within which to find the maximum value
-     * @return the maximum value of the function within the specified section
+     * @return the maximum value within the specified section
      */
-    default double getMaxValue(Section section) {
-        return getMaxPoint(section).getY();
+    default double getMaxValueUnimodal(Section section) {
+        return getMaxPointUnimodal(section).getY();
     }
 
     /**
-     * @param section the section within which to find the maximum point
-     * @return the y value of the function's optimum
+     * Gets the optimum (max signed value) of the function within a specific section using unimodal optimization.
+     * @param section the section within which to find the optimum
+     * @return the y value of the function's optimum within the specified section
      */
-    default double getMaxSignedValue(Section section) {
-        return getMaxSignedValuePoint(section).getY();
+    default double getMaxSignedValueUnimodal(Section section) {
+        return getMaxSignedValuePointUnimodal(section).getY();
     }
 }

--- a/src/main/java/com/wecca/canoeanalysis/utils/CalculusUtils.java
+++ b/src/main/java/com/wecca/canoeanalysis/utils/CalculusUtils.java
@@ -255,9 +255,11 @@ public class CalculusUtils
      *
      * @param functions The list of bounded univariate functions.
      * @param sections  The list of sections that correspond to each function.
+     * @param useUnimodalOptimization, an extra flag to optimize the function faster for quick calculations which only works for unimodal functions
+     *                                 it is up to the implementer to understand if the function is unimodal as the cost to validate for this makes the optimization it provides redundant!
      * @return The shifted composite function.
      */
-    public static BoundedUnivariateFunction createCompositeFunctionShiftedPositive(List<BoundedUnivariateFunction> functions, List<Section> sections) {
+    public static BoundedUnivariateFunction createCompositeFunctionShiftedPositive(List<BoundedUnivariateFunction> functions, List<Section> sections, boolean useUnimodalOptimization) {
         if (functions.size() != sections.size())
             throw new IllegalArgumentException("The number of functions must match the number of sections.");
 
@@ -273,17 +275,21 @@ public class CalculusUtils
         };
 
         Section fullSection = new Section(sections.getFirst().getX(), sections.getLast().getRx());
-        return x -> f.value(x) - f.getMinValue(fullSection);
+        double minValue = useUnimodalOptimization ? f.getMinValueUnimodal(fullSection) : f.getMinValue(fullSection);
+        return x -> f.value(x) - minValue;
     }
 
     /**
      * Essentially an overload of createCompositeFunctionShiftedPositive
      * @param functions the cubic bezier functions which have the section encoded into their constructions points
+     * @param useUnimodalOptimization, an extra flag to optimize the function faster for quick calculations which only works for unimodal functions
+     *                                 it is up to the implementer to understand if the function is unimodal as the cost to validate for this makes the optimization it provides redundant!
      * @return the shifted bezier spline based function.
      */
-    public static BoundedUnivariateFunction createBezierSplineFunctionShiftedPositive(List<CubicBezierFunction> functions) {
+    @Traceable
+    public static BoundedUnivariateFunction createBezierSplineFunctionShiftedPositive(List<CubicBezierFunction> functions, boolean useUnimodalOptimization) {
         List<BoundedUnivariateFunction> functionsMapped = functions.stream().map(CubicBezierFunction::getFunction).toList();
         List<Section> sections = functions.stream().map(f -> new Section(f.getX1(), f.getX2())).toList();
-        return createCompositeFunctionShiftedPositive(functionsMapped, sections);
+        return createCompositeFunctionShiftedPositive(functionsMapped, sections, useUnimodalOptimization);
     }
 }


### PR DESCRIPTION
Brent's method was causing problems rendering uniformly distributed load graphics (ArrowBoundCurveGraphic object) with Brent's method optimization, because uniformly distrusted loads are not unimodal load distributions and thus brent's method cannot be used. thus a feature flag was implemented to choose when to use the new algorithm.